### PR TITLE
手持端原材料发料，及优化

### DIFF
--- a/newbiest-gc/src/main/java/com/newbiest/gc/GcExceptions.java
+++ b/newbiest-gc/src/main/java/com/newbiest/gc/GcExceptions.java
@@ -101,4 +101,5 @@ public class GcExceptions {
     public static final String UNRESERVED_MATERIAL_DONOT_CHECK_DOCUMENT = "gc.reserved_material_donot_check_document";
     public static final String MATERIAL_TYPE_IS_NOT_SAME = "gc.material_type_is_not_same";
     public static final String MATERIAL_TYPE_AND_MATERIAL_LOT_IS_NOT_SAME = "gc.material_type_and_material_lot_is_not_same";
+    public static final String RAW_DOCUMENT_LINE_IS_EMPTY = "gc.raw_document_line_is_empty";
 }

--- a/newbiest-gc/src/main/java/com/newbiest/gc/rest/GCRawMaterialImportManager/RawMaterialSave/GCRawMaterialSaveController.java
+++ b/newbiest-gc/src/main/java/com/newbiest/gc/rest/GCRawMaterialImportManager/RawMaterialSave/GCRawMaterialSaveController.java
@@ -60,6 +60,8 @@ public class GCRawMaterialSaveController {
             gcService.scrapRawMaterialShip(requestBody.getDocumentLine(), requestBody.getMaterialLotList());
         } else if(GCRawMaterialSaveRequest.ACTION_TYPE_GC_UN_RAW_MATERIAL_SPARE.equals(actionType)){
             gcService.unRawMaterialSpare(requestBody.getMaterialLotList());
+        } else if (GCRawMaterialSaveRequest.ACTION_TYPE_MOBILE_ISSUE.equals(actionType)){
+            gcService.mobileValidateAndRawMaterialIssue(materialLotList, requestBody.getErpTime(), GCRawMaterialSaveRequest.ISSUE_WITH_DOC);
         } else {
             throw new ClientException(Request.NON_SUPPORT_ACTION_TYPE + requestBody.getActionType());
         }

--- a/newbiest-gc/src/main/java/com/newbiest/gc/rest/GCRawMaterialImportManager/RawMaterialSave/GCRawMaterialSaveRequest.java
+++ b/newbiest-gc/src/main/java/com/newbiest/gc/rest/GCRawMaterialImportManager/RawMaterialSave/GCRawMaterialSaveRequest.java
@@ -32,5 +32,9 @@ public class GCRawMaterialSaveRequest extends Request {
 
     public static final String ACTION_TYPE_GC_UN_RAW_MATERIAL_SPARE = "GCUnRawMaterialSpare";
 
+    public static final String ACTION_TYPE_MOBILE_ISSUE = "MobileRawIssue";
+
+    public static final String ISSUE_WITH_DOC = "issueWithDoc";
+
     private GCRawMaterialSaveRequestBody body;
 }

--- a/newbiest-gc/src/main/java/com/newbiest/gc/rest/GCRawMaterialImportManager/RawMaterialSave/GCRawMaterialSaveRequestBody.java
+++ b/newbiest-gc/src/main/java/com/newbiest/gc/rest/GCRawMaterialImportManager/RawMaterialSave/GCRawMaterialSaveRequestBody.java
@@ -47,4 +47,7 @@ public class GCRawMaterialSaveRequestBody extends RequestBody {
 
     @ApiModelProperty(value = "发料绑定单据")
     private String issueWithDoc;
+
+    @ApiModelProperty(value = "手持端发料单据日期")
+    private String erpTime;
 }

--- a/newbiest-gc/src/main/java/com/newbiest/gc/service/GcService.java
+++ b/newbiest-gc/src/main/java/com/newbiest/gc/service/GcService.java
@@ -45,6 +45,7 @@ public interface GcService {
 
     String importRawMaterialLotList(List<MaterialLot> materialLotList, String importType) throws ClientException;
     void validateAndRawMaterialIssue(List<DocumentLine> documentLineList, List<MaterialLot> materialLots, String issueWithDoc) throws ClientException;
+    void mobileValidateAndRawMaterialIssue(List<MaterialLot> materialLots, String erpTime, String issueWithDoc) throws ClientException;
     void scrapRawMaterial(List<MaterialLot> materialLotList, String reason, String remarks) throws ClientException;
     void receiveRawMaterial(List<MaterialLot> materialLotList) throws ClientException;
     void deleteMaterialLotAndSaveHis(List<MaterialLot> materialLotList, String deleteNote) throws ClientException;

--- a/newbiest-gc/src/main/resources/db/changelog/db.changelog-add.MobileRawMaterialIssue_nb_table.yaml
+++ b/newbiest-gc/src/main/resources/db/changelog/db.changelog-add.MobileRawMaterialIssue_nb_table.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: add_GCMobileRawMaterialIssue_to_NB_TABLE
+      author: Youqing Huang
+      comment: add GCMobileRawMaterialIssue to nb_table
+      dbms: oracle
+      changes:
+        - createOnLineTable:
+            skipFlag: N
+            nbTable:
+              name: GCMobileRawMaterialIssue
+              description: 手持端原材料发料
+              tableName: MMS_MATERIAL_LOT
+              modelName: MaterialLot
+              modelClass: com.newbiest.mms.model.MaterialLot
+              labelZh: 手持端原材料发料
+              label: MobileRawMaterialIssue

--- a/newbiest-gc/src/main/resources/db/changelog/db.changelog-gc.yaml
+++ b/newbiest-gc/src/main/resources/db/changelog/db.changelog-gc.yaml
@@ -617,4 +617,7 @@ databaseChangeLog:
   - include:
       file: db.changelog-add.MobileTransferBoxChangeStorage_nb_table.yaml
       relativeToChangelogFile: true
+  - include:
+      file: db.changelog-add.MobileRawMaterialIssue_nb_table.yaml
+      relativeToChangelogFile: true
 

--- a/newbiest-mm/src/main/java/com/newbiest/mms/model/MaterialLot.java
+++ b/newbiest-mm/src/main/java/com/newbiest/mms/model/MaterialLot.java
@@ -123,6 +123,7 @@ public class MaterialLot extends NBUpdatable implements StatusLifeCycle{
     public static final String MLOT_THREESIDE_DOC_VALIDATE_RULE_ID = "MLotThreeSideDocRule";  //三方销售单据验证规则
     public static final String RW_MLOT_STOCK_OUT_DOC_VALIDATE_RULE_ID = "RwMLotStockOutDocRule";  //RW出货单据验证规则
     public static final String RW_MLOT_SCRAP_AND_SHIP_VALIDATE_RULE_ID = "RwMaterialScrapShipDocRule";  //原材料报废出库单据验证规则
+    public static final String MOBILE_RAW_ISSUE_WHERE_CLAUSE="GCRawMaterialIssueOrder";
 
     /**
      * 香港仓依订单出货

--- a/newbiest-mm/src/main/java/com/newbiest/mms/service/impl/MaterialLotUnitServiceImpl.java
+++ b/newbiest-mm/src/main/java/com/newbiest/mms/service/impl/MaterialLotUnitServiceImpl.java
@@ -409,6 +409,7 @@ public class MaterialLotUnitServiceImpl implements MaterialLotUnitService {
                     propsMap.put("sourceProductId", materialLotUnit.getSourceProductId());
 
                     propsMap.put("reserved1",materialLotUnit.getReserved1());
+                    propsMap.put("reserved4",materialLotUnit.getTreasuryNote());
                     propsMap.put("reserved6",materialLotUnit.getReserved4());
                     propsMap.put("reserved7",materialLotUnit.getReserved7());
                     propsMap.put("reserved13",materialLotUnit.getReserved13());

--- a/newbiest-mm/src/main/java/com/newbiest/mms/thread/ImportMLotThread.java
+++ b/newbiest-mm/src/main/java/com/newbiest/mms/thread/ImportMLotThread.java
@@ -76,6 +76,7 @@ public class ImportMLotThread implements Callable {
             propsMap.put("sourceProductId", materialLotUnits.get(0).getSourceProductId());
 
             propsMap.put("reserved1",materialLotUnits.get(0).getReserved1());
+            propsMap.put("reserved4",materialLotUnits.get(0).getTreasuryNote());
             propsMap.put("reserved6",materialLotUnits.get(0).getReserved4());
             propsMap.put("reserved7",materialLotUnits.get(0).getReserved7());
             propsMap.put("reserved13",materialLotUnits.get(0).getReserved13());

--- a/newbiest-mm/src/main/resources/db/changelog/db.changelog-add.MobileRawMaterialIssue.nb_authority.yaml
+++ b/newbiest-mm/src/main/resources/db/changelog/db.changelog-add.MobileRawMaterialIssue.nb_authority.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: add_MobileRawMaterialIssueManager_to_NB_AUTHORITY
+      author: Youqing Huang
+      comment: add MobileRawMaterialIssueManager to nb_authority
+      dbms: oracle
+      changes:
+        - createAuthority:
+            skipFlag: N
+            authority:
+              name: MobileRawMaterialIssueManager
+              description: 手持端原材料发料
+              tableName: GCMobileRawMaterialIssue
+              mobileFlag: Y
+              url: /Mobile/MobileRawMaterialIssue
+              parentRrn: 2
+              seqNo: 170
+              image: icon-rule
+              labelZh: 原材料发料
+              labelEn: RawMaterialIssue

--- a/newbiest-mm/src/main/resources/db/changelog/db.changelog-mms.yaml
+++ b/newbiest-mm/src/main/resources/db/changelog/db.changelog-mms.yaml
@@ -689,3 +689,6 @@ databaseChangeLog:
   - include:
       file: db.changelog-add.MobileTransferBoxChangeStorage.nb_authority.yaml
       relativeToChangelogFile: true
+  - include:
+      file: db.changelog-add.MobileRawMaterialIssue.nb_authority.yaml
+      relativeToChangelogFile: true


### PR DESCRIPTION
1.手持端原材料发料功能；
2.RW未测晶圆标注添加“RW成品”和“COM来料”属性转换；
3.保存入库备注。