### PR TITLE
来料导入，手持端”物料查询“优化

### DIFF
--- a/newbiest-gc/src/main/java/com/newbiest/gc/rest/IncomingMaterialImport/IncomingMaterialSave/IncomingMaterialSaveController.java
+++ b/newbiest-gc/src/main/java/com/newbiest/gc/rest/IncomingMaterialImport/IncomingMaterialSave/IncomingMaterialSaveController.java
@@ -50,7 +50,7 @@ public class IncomingMaterialSaveController {
         String checkFourCodeFlag = requestBody.getCheckFourCodeFlag();
 
         String importCode = "";
-        if(MaterialLotUnit.COB_FINISH_PRODUCT.equals(importType) || MaterialLotUnit.SOC_FINISH_PRODUCT.equals(importType)){
+        if(MaterialLotUnit.COB_FINISH_PRODUCT.equals(importType) || MaterialLotUnit.SOC_FINISH_PRODUCT.equals(importType) || MaterialLotUnit.COB_RAW_MATERIAL_PRODUCT.equals(importType)){
             List<MaterialLotUnit> materialLotUnitList = requestBody.getMaterialLotUnitList();
             materialLotUnitList = gcService.validateAndSetWaferSource(importType, checkFourCodeFlag, materialLotUnitList);
             materialLotUnitList = materialLotUnitService.createMLot(materialLotUnitList);

--- a/newbiest-gc/src/main/java/com/newbiest/gc/rest/materiallot/GcMaterialLotController.java
+++ b/newbiest-gc/src/main/java/com/newbiest/gc/rest/materiallot/GcMaterialLotController.java
@@ -1,8 +1,11 @@
 package com.newbiest.gc.rest.materiallot;
 
+import com.google.common.collect.Lists;
 import com.newbiest.base.exception.ClientException;
 import com.newbiest.base.rest.AbstractRestController;
 import com.newbiest.base.ui.model.NBOwnerReferenceList;
+import com.newbiest.base.utils.CollectionUtils;
+import com.newbiest.base.utils.StringUtils;
 import com.newbiest.gc.service.GcService;
 import com.newbiest.mms.model.MaterialLot;
 import com.newbiest.msg.Request;
@@ -65,6 +68,16 @@ public class GcMaterialLotController extends AbstractRestController {
             responseBody.setMaterialLot(materialLot);
         } else if (GcMaterialLotRequest.ACTION_CANCEL_CHECK.equals(actionType)){
             gcService.cancelCheckMaterialLot(requestBody.getMaterialLots(), requestBody.getCancelReason());
+        } else if (GcMaterialLotRequest.ACTION_QUERY_DATA.equals(actionType)) {
+            List<MaterialLot> materialLotList = Lists.newArrayList();
+            materialLotList =  gcService.queryIssueRawMaterialByMaterialLotIdOrLotIdAndTableRrn(requestBody.getQueryLotId(), requestBody.getTableRrn());
+            if (!CollectionUtils.isNotEmpty(materialLotList)) {
+                MaterialLot materialLotIdOrLotId = gcService.getMaterialLotByTableRrnAndMaterialLotIdOrLotId(requestBody.getTableRrn(), requestBody.getQueryLotId());
+                if (!StringUtils.isNullOrEmpty(materialLotIdOrLotId.getMaterialLotId())) {
+                    materialLotList.add(materialLotIdOrLotId);
+                }
+            }
+            responseBody.setMaterialLotList(materialLotList);
         } else {
             throw new ClientException(Request.NON_SUPPORT_ACTION_TYPE + requestBody.getActionType());
         }

--- a/newbiest-gc/src/main/java/com/newbiest/gc/rest/materiallot/GcMaterialLotRequest.java
+++ b/newbiest-gc/src/main/java/com/newbiest/gc/rest/materiallot/GcMaterialLotRequest.java
@@ -50,6 +50,8 @@ public class GcMaterialLotRequest extends Request {
 
 	public static final String ACTION_QUERY_MATERIALLOTID_OR_LOTID = "QueryMaterialLotIdOrLotId";
 
+	public static final String ACTION_QUERY_DATA = "QueryData";
+
 	private GcMaterialLotRequestBody body;
 
 }

--- a/newbiest-gc/src/main/java/com/newbiest/gc/service/impl/GcServiceImpl.java
+++ b/newbiest-gc/src/main/java/com/newbiest/gc/service/impl/GcServiceImpl.java
@@ -5508,7 +5508,7 @@ public class GcServiceImpl implements GcService {
                         materialLotUnit.setReserved7(MaterialLotUnit.PRODUCT_CLASSIFY_WLT);
                         materialLotUnit.setReserved50(MaterialLot.WLT_PACK_RETURN_WAFER_SOURCE);
                         materialLotUnit.setReserved49(MaterialLot.IMPORT_WLT);
-                    } else if(MaterialLotUnit.COB_FINISH_PRODUCT.equals(importType)){
+                    } else if(MaterialLotUnit.COB_RAW_MATERIAL_PRODUCT.equals(importType)){
                         materialLotUnit.setReserved7(MaterialLotUnit.PRODUCT_CLASSIFY_COB);
                         materialLotUnit.setReserved50(MaterialLot.COB_WAFER_SOURCE);
                         materialLotUnit.setReserved49(MaterialLot.IMPORT_COB);
@@ -5516,6 +5516,14 @@ public class GcServiceImpl implements GcService {
                         materialLotUnit.setReserved7(MaterialLotUnit.PRODUCT_CLASSIFY_SOC);
                         materialLotUnit.setReserved50(MaterialLot.SOC_WAFER_SOURCE);
                         materialLotUnit.setReserved49(MaterialLot.IMPORT_SOC);
+                    } else if (MaterialLotUnit.COB_FINISH_PRODUCT.equals(importType)) {
+                        materialLotUnit.setReserved7(MaterialLotUnit.PRODUCT_CLASSIFY_COB);
+                        materialLotUnit.setReserved50(MaterialLot.RW_WAFER_SOURCE);
+                        materialLotUnit.setReserved49(MaterialLot.IMPORT_COB);
+                    } else if (MaterialLotUnit.MASK_FINISH_PRODUCT.equals(importType)) {
+                        materialLotUnit.setReserved7(MaterialLotUnit.PRODUCT_CLASSIFY_MASK);
+                        materialLotUnit.setReserved50(MaterialLot.MASK_WAFER_SOURCE);
+                        materialLotUnit.setReserved49(MaterialLot.IMPORT_MASK);
                     }
                 }
             }
@@ -7772,7 +7780,9 @@ public class GcServiceImpl implements GcService {
                 Iterator<MaterialLot> iterator = materialLots.iterator();
                 while (iterator.hasNext()) {
                     MaterialLot materialLot = iterator.next();
-                    if(MaterialLot.STOCKOUT_TYPE_35.equals(materialLot.getReserved54())){
+                    String materialName = materialLot.getMaterialName();
+                    Integer length = materialName.length();
+                    if(MaterialLot.STOCKOUT_TYPE_35.equals(materialLot.getReserved54()) || MaterialLot.STOCKOUT_TYPE_4.equals(materialName.substring(length - 2, length))){
                         BigDecimal currentQty = materialLot.getCurrentQty();
                         if (unhandedQty.compareTo(currentQty) >= 0) {
                             unhandedQty = unhandedQty.subtract(currentQty);

--- a/newbiest-gc/src/main/resources/db/changelog/db.changelog-add.COBRawMaterialProduct_nb_table.yaml
+++ b/newbiest-gc/src/main/resources/db/changelog/db.changelog-add.COBRawMaterialProduct_nb_table.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: add_GCCOBRawMaterialProduct_to_NB_TABLE
+      author: Youqing Huang
+      comment: add GCCOBRawMaterialProduct to nb_table
+      dbms: oracle
+      changes:
+        - createOnLineTable:
+            skipFlag: N
+            nbTable:
+              name: GCCOBRawMaterialProduct
+              description: COB原料导入
+              tableName: MMS_MATERIAL_LOT_UNIT
+              modelName: MaterialLotUnit
+              modelClass: com.newbiest.mms.model.MaterialLotUnit
+              labelZh: COB原料导入
+              label: COBRawMaterialProduct

--- a/newbiest-gc/src/main/resources/db/changelog/db.changelog-add.GCMaskFinishProduct_nb_table.yaml
+++ b/newbiest-gc/src/main/resources/db/changelog/db.changelog-add.GCMaskFinishProduct_nb_table.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: add_GCMaskFinishProduct_to_NB_TABLE
+      author: Youqing Huang
+      comment: add GCMaskFinishProduct to nb_table
+      dbms: oracle
+      changes:
+        - createOnLineTable:
+            skipFlag: N
+            nbTable:
+              name: GCMaskFinishProduct
+              description: MASK成品导入
+              tableName: MMS_MATERIAL_LOT_UNIT
+              modelName: MaterialLotUnit
+              modelClass: com.newbiest.mms.model.MaterialLotUnit
+              labelZh: MASK成品导入
+              label: GCMaskFinishProduct

--- a/newbiest-gc/src/main/resources/db/changelog/db.changelog-gc.yaml
+++ b/newbiest-gc/src/main/resources/db/changelog/db.changelog-gc.yaml
@@ -668,3 +668,9 @@ databaseChangeLog:
   - include:
       file: db.changelog-add.CobRetestLabelAndMakeUp_nb_table.yaml
       relativeToChangelogFile: true
+  - include:
+      file: db.changelog-add.COBRawMaterialProduct_nb_table.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: db.changelog-add.GCMaskFinishProduct_nb_table.yaml
+      relativeToChangelogFile: true

--- a/newbiest-mm/src/main/java/com/newbiest/mms/model/MaterialLot.java
+++ b/newbiest-mm/src/main/java/com/newbiest/mms/model/MaterialLot.java
@@ -200,6 +200,7 @@ public class MaterialLot extends NBUpdatable implements StatusLifeCycle{
     public static final String IMPORT_COG = "COG";
     public static final String IMPORT_SOC = "SOC";
     public static final String IMPORT_FT = "FT";
+    public static final String IMPORT_MASK = "MASK";
 
     /**
      * Wafer Source
@@ -225,6 +226,7 @@ public class MaterialLot extends NBUpdatable implements StatusLifeCycle{
     public static final String CP_CHANGGE_RW_WAFER_SOURCE = "21";
     public static final String SOC_WAFER_SOURCE_UNMEASUREN = "13";
     public static final String SOC_WAFER_SOURCE_MEASURE = "14";
+    public static final String MASK_WAFER_SOURCE = "99";
 
     /**
      * 根据产品结尾数字获取WaferSource

--- a/newbiest-mm/src/main/java/com/newbiest/mms/model/MaterialLotUnit.java
+++ b/newbiest-mm/src/main/java/com/newbiest/mms/model/MaterialLotUnit.java
@@ -56,12 +56,13 @@ public class MaterialLotUnit extends NBUpdatable {
     public static final String RMA_RETURN = "GCRMACustomerReturnFinishProduct";//RMA_客户退货_成品
     public static final String RMA_PURE = "GCRMAPureFinishProduct";//RMA纯_成品-4
     public static final String COB_FINISH_PRODUCT = "GCCOBFinishProduct"; //COB（-4成品）
+    public static final String COB_RAW_MATERIAL_PRODUCT = "GCCOBRawMaterialProduct"; //COM原料导入
     public static final String LCD_COG_FINISH_PRODUCT = "GCLCDCOGFinishProductEcretive";//LCD（COG成品-ECRETIVE）
     public static final String LCD_COG_DETIAL = "GCLcdCogDetial";//LCD(COG成品-明细)
     public static final String FINISH_PRODUCT_IMPORT = "GCFinishProductImport";//成品导入模板
-    public static final String SOC_FINISH_PRODUCT = "GCSOCFinishProduct"; //COB（-4成品）
+    public static final String SOC_FINISH_PRODUCT = "GCSOCFinishProduct"; //SOC成品
     public static final String SOC_WAFER_UNMEASURED = "GCSOCWaferUnmeasured"; //SOC晶圆未测、已测
-
+    public static final String MASK_FINISH_PRODUCT= "GCMaskFinishProduct"; //MASK成品
 
     //产品型号
     public static final String PRODUCT_CLASSIFY_CP = "CP0";
@@ -72,6 +73,7 @@ public class MaterialLotUnit extends NBUpdatable {
     public static final String PRODUCT_CLASSIFY_COB = "COB0";
     public static final String PRODUCT_CLASSIFY_COG = "COG0";
     public static final String PRODUCT_CLASSIFY_SOC = "SOC0";
+    public static final String PRODUCT_CLASSIFY_MASK = "MASK0";
 
     public static final String PRODUCT_CATEGORY_WLT = "WLT";
     public static final String PRODUCT_CATEGORY_CP = "CP";


### PR DESCRIPTION
1. 修改“来料导入”中的“COB(-4成品)”为“COM原料导入”；
2. 添加“COB成品”导入在“来料导入”中；
3. 添加“SOC成品”导入在“来料导入”中；
4. 添加“MASK成品”导入在“来料导入”中；
5.优化“按其他订单出货”的形态。
6.优化手持端”物料查询“，可查询COM，晶圆，原材料的库存信息。