### PR TITLE
WMS来料导入型号转换

### DIFF
--- a/newbiest-gc/src/main/java/com/newbiest/gc/service/impl/GcServiceImpl.java
+++ b/newbiest-gc/src/main/java/com/newbiest/gc/service/impl/GcServiceImpl.java
@@ -98,6 +98,8 @@ public class GcServiceImpl implements GcService {
     public static final String BONDED_PROPERTITY_ZSH = "ZSH";
     public static final String BONDED_PROPERTITY_HK = "HK";
 
+    public static final String PRE_FIX_GCB = "GCB";
+
     @Autowired
     MesPackedLotRepository mesPackedLotRepository;
 
@@ -7510,16 +7512,22 @@ public class GcServiceImpl implements GcService {
                         materialLotUnit.setSourceProductId(materialName);
                         materialName = productModelConversion.getConversionModelId();
                         material = mmsService.getRawMaterialByName(materialName);
-                        if(material == null){
-                            RawMaterial rawMaterial = new RawMaterial();
-                            rawMaterial.setName(materialName);
-                            material = mmsService.createRawMaterial(rawMaterial);
-                        }
                     } else {
-                        material = mmsService.getRawMaterialByName(materialName);
-                        if(material == null){
-                            throw new ClientParameterException(MM_RAW_MATERIAL_IS_NOT_EXIST, materialName);
+                        //后两位是'-3'转变成'-3.5'
+                        if (materialName.endsWith("-3")){
+                            materialName = materialName + ".5";
+                            material = mmsService.getRawMaterialByName(materialName);
+                        }else {
+                            material = mmsService.getRawMaterialByName(materialName);
+                            if (material == null){
+                                throw new ClientParameterException(MM_RAW_MATERIAL_IS_NOT_EXIST, materialName);
+                            }
                         }
+                    }
+                    if (material == null){
+                        material = new RawMaterial();
+                        material.setName(materialName);
+                        material = mmsService.createRawMaterial((RawMaterial) material);
                     }
                 } else if(Integer.parseInt(mesPackedLotRelation.getBinId1() == null ? "0" : mesPackedLotRelation.getBinId1()) < Integer.parseInt(materialLotUnit.getReserved34()) ||
                             Integer.parseInt(mesPackedLotRelation.getBinId2() == null ? "0" : mesPackedLotRelation.getBinId2()) < Integer.parseInt(materialLotUnit.getReserved42()) ||
@@ -7540,10 +7548,6 @@ public class GcServiceImpl implements GcService {
                 materialLotUnit.setReserved7(MaterialLotUnit.PRODUCT_CLASSIFY_WLT);
                 materialLotUnit.setReserved49(MaterialLot.IMPORT_WLT);
                 materialLotUnit.setReserved50("7");
-
-                String levelTwoCode = materialLotUnit.getReserved1();
-                String substring = materialLotUnit.getReserved30().substring(0, 1);
-                materialLotUnit.setReserved1(levelTwoCode + substring);
             }
             materialLotUnitList = materialLotUnitService.createFTMLot(materialLotUnitList);
             return materialLotUnitList;
@@ -8862,9 +8866,20 @@ public class GcServiceImpl implements GcService {
                 materialLotUnit.setReserved49(MaterialLot.IMPORT_SENSOR);
                 materialLotUnit.setReserved50(MaterialLot.SENSOR_WAFER_SOURCE);
 
-                String levelTwoCode = materialLotUnit.getReserved1();
-                String substring = materialLotUnit.getReserved30().substring(0, 1);
-                materialLotUnit.setReserved1(levelTwoCode + substring);
+                //sensor封装回货(-3未测) 如果materialName未配置,materialName后缀为"-3"转换为"-3.5"。
+                if (MaterialLotUnit.SENSOR_PACK_RETURN.equals(importType)){
+                    GCProductModelConversion productModelConversion = gcProductModelConversionRepository.findByProductIdAndModelCategory(materialLotUnit.getMaterialName(), MaterialLot.IMPORT_FT);
+                    if(productModelConversion == null && materialLotUnit.getMaterialName().endsWith("-3")){
+                        materialLotUnit.setMaterialName(materialLotUnit.getMaterialName() + ".5");
+
+                        RawMaterial material = mmsService.getRawMaterialByName(materialLotUnit.getMaterialName());
+                        if(material == null){
+                            material = new RawMaterial();
+                            material.setName(materialLotUnit.getMaterialName());
+                            material = (RawMaterial) mmsService.createRawMaterial(material);
+                        }
+                    }
+                }
             }
             materialLotUnits = materialLotUnitService.createFTMLot(materialLotUnits);
 
@@ -10808,8 +10823,12 @@ public class GcServiceImpl implements GcService {
                 if(CollectionUtils.isEmpty(mLotList)){
                     throw new ClientParameterException(MmsException.MM_MATERIAL_LOT_IS_NOT_EXIST, queryLotId);
                 } else {
-                    materialLot = mLotList.get(0);
-                    materialLots.add(materialLot);
+                    if(!StringUtils.isNullOrEmpty(materialLot.getLotId())  && materialLot.getLotId().startsWith(PRE_FIX_GCB)){
+                        materialLots.addAll(mLotList);
+                    }else {
+                        materialLot = mLotList.get(0);
+                        materialLots.add(materialLot);
+                    }
                 }
             }
             return materialLots;
@@ -11497,5 +11516,4 @@ public class GcServiceImpl implements GcService {
             throw ExceptionManager.handleException(e, log);
         }
     }
-
 }

--- a/newbiest-mm/src/main/java/com/newbiest/mms/service/impl/MaterialLotUnitServiceImpl.java
+++ b/newbiest-mm/src/main/java/com/newbiest/mms/service/impl/MaterialLotUnitServiceImpl.java
@@ -428,9 +428,9 @@ public class MaterialLotUnitServiceImpl implements MaterialLotUnitService {
                     if(MaterialLotUnit.PRODUCT_TYPE_ENG.equals(materialLotUnit.getProductType())){
                         propsMap.put("productType", MaterialLotUnit.PRODUCT_TYPE_ENG);
                     }
-                    //FT导入的产品-3.5的二级代码为三位的转换为四位
+                    //FT导入的产品二级代码为三位的转换为四位
                     String subCode = materialLotUnit.getReserved1();
-                    if(materialName.endsWith("-3.5") && !StringUtils.isNullOrEmpty(subCode) && subCode.length() == 3){
+                    if(!StringUtils.isNullOrEmpty(subCode) && subCode.length() == 3){
                         subCode = subCode + materialLotUnit.getUnitId().substring(0,1);
                     }
                     propsMap.put("supplier", materialLotUnit.getSupplier());


### PR DESCRIPTION
1.物料批次批量hold，导入查询如果lot_id前缀‘GCB’则不get(0)
2.FT来料导入删除二级代码3位转4位的多余逻辑.
3.WLT封装回货/Sensor封装回货(-3未测)，若material_Name未配置，则后缀‘-3’转‘-3.5’.需求 #43691。