### PR TITLE
Gc wms v2

### DIFF
--- a/newbiest-mm/src/main/java/com/newbiest/mms/thread/ImportMLotThread.java
+++ b/newbiest-mm/src/main/java/com/newbiest/mms/thread/ImportMLotThread.java
@@ -135,6 +135,7 @@ public class ImportMLotThread implements Callable {
                 materialLotUnit.setMaterialLotRrn(materialLot.getObjectRrn());
                 materialLotUnit.setMaterialLotId(materialLot.getMaterialLotId());
                 materialLotUnit.setLotId(materialLot.getLotId());
+                materialLotUnit.setReserved1(materialLot.getReserved1());
                 materialLotUnit.setReceiveQty(materialLotUnit.getCurrentQty());
                 materialLotUnit.setCurrentSubQty(BigDecimal.ONE);
                 materialLotUnit.setReserved18("0");


### PR DESCRIPTION
wla未测2.5导入时，二级代码为3位的修改为4位，取lotId首位