### PR TITLE
 #546 RW出货标注修改

### DIFF
--- a/newbiest-gc/src/main/java/com/newbiest/gc/rest/rw/manager/RwMaterialLotController.java
+++ b/newbiest-gc/src/main/java/com/newbiest/gc/rest/rw/manager/RwMaterialLotController.java
@@ -73,6 +73,11 @@ public class RwMaterialLotController {
             gcService.rwMaterialLotStockOutTag(requestBody.getMaterialLotList(), requestBody.getCustomerName(), requestBody.getAbbreviation(), requestBody.getRemarks());
         } else if(RwMaterialLotRequest.ACTION_ADD_SHIP_ORDERID.equals(actionType)) {
             gcService.rwMaterialLotAddShipOrderId(requestBody.getMaterialLotList(), requestBody.getShipOrderId());
+        } else if(RwMaterialLotRequest.ACTION_CANCEL_SHIP_ORDERID.equals(actionType)){
+            gcService.rwMaterialLotCancelShipOrderId(requestBody.getMaterialLotList());
+        } else if(RwMaterialLotRequest.ACTION_PREVIEW.equals(actionType)){
+            List<MaterialLot> materialLotList = gcService.previewRwShipTagUpdateMaterialLotList(requestBody.getMaterialLotList());
+            responseBody.setMaterialLotList(materialLotList);
         } else if(RwMaterialLotRequest.ACTION_UN_STOCK_OUT_TAG.equals(actionType)){
             gcService.rwMaterialLotCancelStockTag(requestBody.getMaterialLotList());
         } else if(RwMaterialLotRequest.ACTION_QUERY_MLOT.equals(actionType)){

--- a/newbiest-gc/src/main/java/com/newbiest/gc/rest/rw/manager/RwMaterialLotRequest.java
+++ b/newbiest-gc/src/main/java/com/newbiest/gc/rest/rw/manager/RwMaterialLotRequest.java
@@ -26,6 +26,10 @@ public class RwMaterialLotRequest extends Request {
 	
 	public static final String ACTION_ADD_SHIP_ORDERID = "AddShipOrderId";
 
+	public static final String ACTION_CANCEL_SHIP_ORDERID = "CancelShipOrderId";
+
+	public static final String ACTION_PREVIEW = "PreView";
+
 	public static final String ACTION_QUERY_MLOT = "QueryMLot";
 
 	public static final String ACTION_STOCK_OUT = "StockOut";

--- a/newbiest-gc/src/main/java/com/newbiest/gc/service/GcService.java
+++ b/newbiest-gc/src/main/java/com/newbiest/gc/service/GcService.java
@@ -35,6 +35,8 @@ public interface GcService {
     void rwStockOut(List<MaterialLot> materialLotList, List<DocumentLine> documentLineList) throws ClientException;
     void rwMaterialLotCancelStockTag(List<MaterialLot> materialLotList) throws ClientException;
     void rwMaterialLotAddShipOrderId(List<MaterialLot> materialLotList, String shipOrderId) throws ClientException;
+    void rwMaterialLotCancelShipOrderId(List<MaterialLot> materialLotList) throws ClientException;
+    List<MaterialLot> previewRwShipTagUpdateMaterialLotList(List<MaterialLot> materialLotList) throws ClientException;
     void rwMaterialLotStockOutTag(List<MaterialLot> materialLotList, String customerName, String abbreviation, String remarks) throws ClientException;
     List<MaterialLot> rwTagginggAutoPickMLot(List<MaterialLot> materialLotList, BigDecimal pickQty) throws ClientException;
     List<MesPackedLot> receiveRWFinishPackedLot(List<MesPackedLot> packedLots, String printLabel, String printCount) throws ClientException;

--- a/newbiest-gc/src/main/resources/db/changelog/db.changelog-add.GCRwStockOutTagUpdateMLotShow_nb_table.yaml
+++ b/newbiest-gc/src/main/resources/db/changelog/db.changelog-add.GCRwStockOutTagUpdateMLotShow_nb_table.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: add_GCRwStockOutTagUpdateMLotShow_to_NB_TABLE
+      author: Guozhang Luo
+      comment: add GCRwStockOutTagUpdateMLotShow to nb_table
+      dbms: oracle
+      changes:
+        - createOnLineTable:
+            skipFlag: N
+            nbTable:
+              name: GCRwStockOutTagUpdateMLotShow
+              description: COB出货标注修改展示
+              tableName: MMS_MATERIAL_LOT
+              modelName: MaterialLot
+              modelClass: com.newbiest.mms.model.MaterialLot
+              labelZh: COB出货标注修改展示
+              label: RwStockOutTagUpdateShow

--- a/newbiest-gc/src/main/resources/db/changelog/db.changelog-gc.yaml
+++ b/newbiest-gc/src/main/resources/db/changelog/db.changelog-gc.yaml
@@ -845,3 +845,6 @@ databaseChangeLog:
   - include:
       file: db.changelog-0.0.2.add.mobile_menu_nb_authority.yaml
       relativeToChangelogFile: true
+  - include:
+      file: db.changelog-add.GCRwStockOutTagUpdateMLotShow_nb_table.yaml
+      relativeToChangelogFile: true

--- a/newbiest-mm/src/main/java/com/newbiest/mms/model/MaterialLot.java
+++ b/newbiest-mm/src/main/java/com/newbiest/mms/model/MaterialLot.java
@@ -148,6 +148,8 @@ public class MaterialLot extends NBUpdatable implements StatusLifeCycle{
     public static final String WLT_OTHER_STOCK_OUT_RULE_ID = "WltOtherStockOutRule";  //WLT/CP其它出单据验证规则
     public static final String FT_RETEST_DOC_VALIDATE_RULE_ID = "FtVboxReTestRule"; //FT真空包重测发料单据验证规则
 
+    public static final String RW_SHIP_TAG_UPDATE_PREVIEW_RULE_ID = "RwShipTagUpdatePreviewRule"; //COB出货标注修改分组筛选
+
     public static final String MOBILE_RAW_ISSUE_WHERE_CLAUSE="GCRawMaterialIssueOrder";
     public static final String MOBILE_RETEST_WHERE_CLAUSE = "GCReTestManager";
     public static final String MOBILE_WLT_OR_CP_STOCK_OUT_ORDER_WHERE_CLAUSE = "GCWltOrCpStockOutOrder";

--- a/newbiest-mm/src/main/java/com/newbiest/mms/model/MaterialLotHistory.java
+++ b/newbiest-mm/src/main/java/com/newbiest/mms/model/MaterialLotHistory.java
@@ -35,6 +35,7 @@ public class MaterialLotHistory extends NBHis {
     public static final String TRANS_TYPE_RAW_UN_SPARE = "UnSpare";
     public static final String TRANS_TYPE_UPDATE = "Update";
     public static final String TRANS_TYPE_ADD_SHIP_ORDER_ID = "AddShipOrderId";
+    public static final String TRANS_TYPE_CANCEL_SHIP_ORDER_ID = "CancelShipOrderId";
     public static final String TRANS_TYPE_MATERIAL_SPARE = "MaterialSpare";
     public static final String TRANS_TYPE_CANCEL_MATERIAL_SPARE = "MaterialCancel";
     public static final String TRANS_TYPE_TRANSFER_WAREHOUSE = "TransferWarehouse";


### PR DESCRIPTION
1、查询条件等级、二级代码筛选列标中物料批次中包含的等级何二级代码；
2、入库备注支持模糊查询；
3、添加导出按钮
4、新增栏位记录标注人、标注时间（年月日）
6、新增“取消发货单”按钮，清除发货单信息；
7、新增数量统计按钮，按照（标注信息、供应商、产品类型、等级、二级代码、入库备注）分组，显示总数量。